### PR TITLE
Fixed Favicon issue in Docs by adding withPrefix

### DIFF
--- a/src/gatsby-theme-apollo-docs/components/custom-seo.js
+++ b/src/gatsby-theme-apollo-docs/components/custom-seo.js
@@ -6,7 +6,7 @@ import { withPrefix } from "gatsby";
 export default function CustomSEO({ image, baseUrl, twitterHandle, ...props }) {
   const imagePath = `${baseUrl}${withPrefix("/social-card.png")}`;
   return (
-    <SEO {...props} favicon={"/favicon.png"} twitterCard="summary_large_image">
+    <SEO {...props} favicon={withPrefix("/favicon.png")} twitterCard="summary_large_image">
       <meta property="og:image" content={imagePath} />
       {baseUrl && <meta name="twitter:image" content={imagePath} />}
       {twitterHandle && (


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
-->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] You have read the [Contribution Guidlines](https://github.com/LoginRadius/docs/blob/master/CONTRIBUTING.md) before creating this PR.

##### Description of change

<!-- In case of a bug please provide a short description of what is changed and add link of the relevant issue after this comment-->

* Currently the favicon is not showing up in prod, because of PATH_PREFIX, hence added `withPrefix` to support the same.