### PR TITLE
Redirected phone login guide link

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -205,3 +205,7 @@ to = "/docs/developer/guide/wordpress"
 [[redirects]]
   from = "/docs/developer/references/sdk/golang"
   to = "/docs/developer/references/sdk/golang-sdk"
+
+[[redirects]]
+  from = "/docs/developer/howto/manage-phone-login/"
+  to = "/docs/developer/guide/phone-login"


### PR DESCRIPTION
Redirects from /howto/manage-phone-login to /docs/developer/guide/phone-login